### PR TITLE
Fix for deep symbolic links on linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /nbproject/
+node_modules

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 /* Copyright 2013 Joseph Spencer.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *       http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,7 +22,7 @@ var exec = child_process.exec;
 var exists = fs.existsSync;
 var readlink = fs.readlinkSync;
 var resolve = path.resolve;
-
+var lstat = fs.lstatSync;
 var javaHome;
 
 module.exports = findJavaHome;
@@ -44,7 +44,7 @@ function findJavaHome(cb){
         'reg',
         'query',
         '"hkey_local_machine\\software\\javasoft\\java development kit"'
-      ].join(' '), 
+      ].join(' '),
       function(error, out, err){
         var reg = /\\([0-9]\.[0-9])$/;
         var key;
@@ -85,7 +85,7 @@ function findJavaHome(cb){
     if(err)return next(cb, err, null);
 
     //resolve symlinks
-    proposed = readlink(proposed);
+    proposed = findLinkedFile(proposed);
 
     //get the /bin directory
     proposed = dirname(proposed);
@@ -107,6 +107,13 @@ function findJavaHome(cb){
 
     next(cb, null, javaHome);
   });
+}
+
+// iterate through symbolic links until
+// file is found
+function findLinkedFile(file){
+    if(!lstat(file).isSymbolicLink()) return file;
+    return findLinkedFile(readlink(file));
 }
 
 function next(){

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "find-java-home",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Find JAVA_HOME on any system",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
There are sometimes more than one level of symobolic links on the java file.
I've added a recursive symbolic link function (which tests as it goes) to find the origin directory.
