### PR TITLE
Try more registry values for windows.

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,17 @@ var javaHome;
 
 module.exports = findJavaHome;
 
-function findJavaHome(cb){
+function findJavaHome(){
+  var args = [].slice.apply(arguments);
+  var options = {allowJre: false};
+  if(args.length === 2) {
+    var cb = args[1];
+    for(var key in args[0]){
+      if(args[0].hasOwnProperty(key)) options[key] = args[0][key];
+    }
+  } else {
+    var cb = args[0];
+  }
   var macUtility;
 
   if(process.env.JAVA_HOME && dirIsJavaHome(process.env.JAVA_HOME)){
@@ -41,13 +51,21 @@ function findJavaHome(cb){
   //windows
   if(process.platform.indexOf('win') === 0){
     //java_home can be in many places
+    //JDK paths
     var possibleKeyPaths =
       [
         '"hklm\\software\\javasoft\\java development kit"',
-        '"hklm\\software\\javasoft\\java runtime environment"',
-        '"hklm\\software\\wow6432node\\javasoft\\java development kit"',
-        '"hklm\\software\\wow6432node\\javasoft\\java runtime environment"'
+        '"hklm\\software\\wow6432node\\javasoft\\java development kit"'
       ];
+    //JRE paths
+    if(options.allowJre){
+      possibleKeyPaths.concat(
+        [
+          '"hklm\\software\\javasoft\\java runtime environment"',
+          '"hklm\\software\\wow6432node\\javasoft\\java runtime environment"'
+        ]
+      );
+    }
     var errors = [];
     var failed = after(possibleKeyPaths.length, function() {
       return next(cb, errors.join('\r\n'), null)

--- a/test.js
+++ b/test.js
@@ -50,4 +50,12 @@ describe('find-java-home', function(){
       });
     });
   });
+
+  describe('when given options', function() {
+    it('should still java home', function(done) {
+      sut({allowJre: true}, function(err, home) {
+        done(err);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Here's one option for fixing the registry issue. I added a dependency on underscore for [`_.after`](http://underscorejs.org/#after). If it gets as many errors as there are keyPaths to check, then it fails as it should. If you would prefer to not have the dependency, I can write an implementation of `after` locally. Double check that there aren't any new bugs introduced here, race condition maybe?

If you'd prefer something else, or any changes to the code, let me know.

Fixes #4.
