### PR TITLE
Extended check for javac to include the exe extension for Windows systems

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,7 +160,9 @@ function next(cb, err, home){
 function dirIsJavaHome(dir){
   return exists(''+dir)
     && stat(dir).isDirectory()
-    && exists(path.resolve(dir, 'bin', 'javac'));
+    && (exists(path.resolve(dir, 'bin', 'javac'))
+      || exists(path.resolve(dir, 'bin', 'javac.exe'))
+      );
 }
 
 function after(count, cb){


### PR DESCRIPTION
The check for javac using registry values was returning a false negative because some systems contain the javac.exe file, which was not being resolved.