### PR TITLE
remove newline at end of path returned from java_home

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ function findJavaHome(options, cb){
     if(exists(macUtility)){
       exec(macUtility, {cwd:proposed}, function(error, out, err){
         if(error || err)return next(cb, error || ''+err, null);
-        javaHome = ''+out;
+        javaHome = ''+out.replace(/\\n$/, '');
         next(cb, null, javaHome);
       }) ;
       return;


### PR DESCRIPTION
When the java_home utility runs on my machine, it returns the path with a newline at the end of the path, causing an error to be thrown.  Using this change will all for the removal of the newline at the end, if it exists.