### PR TITLE
escape in regexp requires only one backslash

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ function findJavaHome(options, cb){
     if(exists(macUtility)){
       exec(macUtility, {cwd:proposed}, function(error, out, err){
         if(error || err)return next(cb, error || ''+err, null);
-        javaHome = ''+out.replace(/\\n$/, '');
+        javaHome = ''+out.replace(/\n$/, '');
         next(cb, null, javaHome);
       }) ;
       return;


### PR DESCRIPTION
This prevents java auto detection on macOS.