### PR TITLE
Support to find JDK 11/12 from Windows registry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import WinReg, { Registry } from "winreg";
 
 const isWindows: boolean = process.platform.indexOf('win') === 0;
 const jdkRegistryKeyPaths: string[] = [
+    "\\SOFTWARE\\JavaSoft\\JDK",
     "\\SOFTWARE\\JavaSoft\\Java Development Kit"
 ];
 const jreRegistryKeyPaths: string[] = [


### PR DESCRIPTION
This PR fixes #19 , below is my registry after installing Oracle JDKs on my x64 win10.

#### Oracle JDK 11
-	[HKEY_LOCAL_MACHINE\SOFTWARE\JavaSoft\JDK]
"CurrentVersion"="11.0.3"
- 	[HKEY_LOCAL_MACHINE\SOFTWARE\JavaSoft\JDK\11.0.3]
"JavaHome"="C:\\Program Files\\Java\\jdk-11.0.3"
#### Oracle JDK 12
- 	[HKEY_LOCAL_MACHINE\SOFTWARE\JavaSoft\JDK]
"CurrentVersion"="12.0.1"
- 	[HKEY_LOCAL_MACHINE\SOFTWARE\JavaSoft\JDK\12.0.1]
"JavaHome"="C:\\Program Files\\Java\\jdk-12.0.1"
