### PR TITLE
Fix TS definition for import

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ require('find-java-home')(function(err, home){
 });
 
 // OR
-import findJavaHome from 'find-java-home';
+import * as findJavaHome from 'find-java-home';
 findJavaHome({allowJre: true}, (err, home) => {
   if(err)return console.log(err);
   console.log(home);

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,19 +28,22 @@ const jreRegistryKeyPaths: string[] = [
     "\\SOFTWARE\\JavaSoft\\Java Runtime Environment"
 ];
 
-interface IOptions { allowJre: boolean };
+declare namespace findJavaHome {
+    interface IOptions { allowJre: boolean }
+}
+
 type Callback = (err: Error, res: any) => void;
 
 function findJavaHome(cb: Callback): void;
-function findJavaHome(options: IOptions, cb: Callback): void;
-async function findJavaHome(optionsOrCb: IOptions | Callback, optional?: Callback) {
+function findJavaHome(options: findJavaHome.IOptions, cb: Callback): void;
+async function findJavaHome(optionsOrCb: findJavaHome.IOptions | Callback, optional?: Callback) {
     let cb: Callback;
-    let options: IOptions | undefined;
+    let options: findJavaHome.IOptions | undefined;
     if (!optional) {
         cb = <Callback>optionsOrCb;
         options = undefined;
     } else {
-        options = <IOptions>optionsOrCb;
+        options = <findJavaHome.IOptions>optionsOrCb;
         cb = optional;
     }
 
@@ -54,7 +57,7 @@ async function findJavaHome(optionsOrCb: IOptions | Callback, optional?: Callbac
     cb(err, res);
 }
 
-async function findJavaHomePromise(options?: IOptions): Promise<string | null> {
+async function findJavaHomePromise(options?: findJavaHome.IOptions): Promise<string | null> {
     const allowJre: boolean = !!(options && options.allowJre);
     const JAVA_FILENAME = (allowJre ? 'java' : 'javac') + (isWindows ? '.exe' : '');
 


### PR DESCRIPTION
`import` statement won't work if `esModuleInterop` is false, which is a common case. 
See below: 
<img width="830" alt="Screen Shot 2019-09-03 at 2 12 20 PM" src="https://user-images.githubusercontent.com/2351748/64148111-03096480-ce55-11e9-8483-c4bc01627adf.png">
<img width="691" alt="Screen Shot 2019-09-03 at 2 11 51 PM" src="https://user-images.githubusercontent.com/2351748/64148114-043a9180-ce55-11e9-8775-ff3fe06220e9.png">

This PR fixes the issue and updates the README. 
