### PR TITLE
Support resolving java from jenv shims

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import * as path from "path";
 import * as cp from "child_process";
 import which from "which";
 import WinReg, { Registry } from "winreg";
+import { execSync } from 'child_process';
 
 const isWindows: boolean = process.platform.indexOf('win') === 0;
 const jdkRegistryKeyPaths: string[] = [
@@ -89,6 +90,15 @@ function findInPath(JAVA_FILENAME: string) {
         which(JAVA_FILENAME, (err, proposed) => {
             if (err || !proposed) {
                 return resolve(null);
+            }
+
+            if (proposed.match(".jenv/shims")) {
+                try {
+                    const jenvProposed: string = execSync(`jenv which ${JAVA_FILENAME}`).toString().trim();
+                    proposed = jenvProposed;
+                } catch (ex) {
+                    console.error(ex);
+                }
             }
 
             //resolve symlinks

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ function findInPath(JAVA_FILENAME: string) {
                 return resolve(null);
             }
 
-            if (proposed.match(".jenv/shims")) {
+            if (/\.jenv\/shims/.test(proposed)) {
                 try {
                     const jenvProposed: string = execSync(`jenv which ${JAVA_FILENAME}`).toString().trim();
                     proposed = jenvProposed;


### PR DESCRIPTION
If the proposed java version looks like a jenv shim, try
calling jenv which on it to really resolve the proposed java

This should resolve this issue https://github.com/jsdevel/node-find-java-home/issues/25