### PR TITLE
Fix bug preventing symbolic links from being correctly resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ simply returns that value.
 2. On windows the registry is queried.
 3. If neither of the previous methods worked, then the PATH is scanned for javac
 4. On mac, the parent directory of javac is checked for a java_home binary.  If that binary exists then it is executed and the result is used
-5. The grandparent directory of javac is used.  This is similar to `$(dirname $(dirname $(readlink $(which javac))))`
+5. The grandparent directory of javac is used.  This is similar to `$(dirname $(dirname $(readlink -e $(which javac))))`
 
 ## Example
 ````javascript

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ function findInPath(JAVA_FILENAME: string) {
             }
 
             //resolve symlinks
-            proposed = findLinkedFile(proposed);
+            proposed = fs.realpathSync(proposed);
 
             //get the /bin directory
             proposed = path.dirname(proposed);
@@ -190,13 +190,6 @@ function dirIsJavaHome(dir: string, javaFilename: string): boolean {
         && fs.existsSync(path.resolve(dir, 'bin', javaFilename));
 }
 
-
-// iterate through symbolic links until
-// file is found
-function findLinkedFile(file: string): string {
-    if (!fs.lstatSync(file).isSymbolicLink()) return file;
-    return findLinkedFile(fs.readlinkSync(file));
-}
 
 export = findJavaHome
 


### PR DESCRIPTION
## Description

If Java is installed using some package managers, such as [`brew`](https://brew.sh/), the `javac` on `PATH` may be a relative symbolic link: `/home/x/.linuxbrew/bin/javac -> ../Cellar/openjdk/15.0.2/bin/javac`.

### Expected Behaviour

An absolute file path should be returned.

In this case, it should be the absolute file path of `../Cellar/openjdk/15.0.2/bin/javac`.

### Actual Behaviour

A relative file path is returned: `../Cellar/openjdk/15.0.2`.

## Fix

This fix uses [`fs.realpathSync`](https://nodejs.org/api/fs.html#fs_fs_realpath_path_options_callback) (rather than `fs.readlinkSync`), which computes the canonical pathname of relative paths and symbolic links.