### PR TITLE
Remove redundant function declaration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,8 +38,6 @@ declare namespace findJavaHome {
 type RegArch = "x86" | "x64";
 type Callback = (err: Error, res: any) => void;
 
-function findJavaHome(cb: Callback): void;
-function findJavaHome(options: findJavaHome.IOptions, cb: Callback): void;
 async function findJavaHome(optionsOrCb: findJavaHome.IOptions | Callback, optional?: Callback) {
     let cb: Callback;
     let options: findJavaHome.IOptions | undefined;


### PR DESCRIPTION
Fixes https://github.com/jsdevel/node-find-java-home/issues/33

Resulting index.d.ts:
```
declare namespace findJavaHome {
    interface IOptions {
        allowJre: boolean;
        registry?: RegArch;
    }
}
declare type RegArch = "x86" | "x64";
declare type Callback = (err: Error, res: any) => void;
declare function findJavaHome(optionsOrCb: findJavaHome.IOptions | Callback, optional?: Callback): Promise<void>;
declare namespace findJavaHome {
    var promise: Promise<string | null>;
}
export = findJavaHome;
```

Original index.d.ts with duplicate `findJavaHome.promise` declaration:
```
declare namespace findJavaHome {
    interface IOptions {
        allowJre: boolean;
        registry?: RegArch;
    }
}
declare type RegArch = "x86" | "x64";
declare type Callback = (err: Error, res: any) => void;
declare function findJavaHome(cb: Callback): void;
declare namespace findJavaHome {
    var promise: Promise<string | null>;
}
declare function findJavaHome(options: findJavaHome.IOptions, cb: Callback): void;
declare namespace findJavaHome {
    var promise: Promise<string | null>;
}
export = findJavaHome;
```
